### PR TITLE
Fix version of jupyterlabs in attempt to resolve performance issues.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pyinaturalist==0.18.0
 arcgis==2.1.0.3
 urllib3==1.26.15  # Fix this version to avoid TypeError: __init__() got an unexpected keyword argument 'method_whitelist'
+jupyterlab==3.6.3  # Fix this version to hopefully overcome GitHub Actions taking 10 minutes to download dependencies since jupyterlab 4.0.0 was released
 func_timeout==4.3.5
 pytz==2023.3
 python-dateutil==2.8.2


### PR DESCRIPTION
GitHub Actions is taking 10 minutes to run, most of which is installing the pip dependencies. See https://github.com/EcoNet-NZ/inaturalist-to-cams/issues/53.