### PR TITLE
Fix #137 iNat visit overwriting more recent CAMS visit or rollover

### DIFF
--- a/config/cams_schema.json
+++ b/config/cams_schema.json
@@ -76,6 +76,11 @@
             "name": "LandOwnership",
             "type": "String",
             "length": 80
+        },
+        "Rollover Audit Log":{
+            "name": "audit_log",
+            "type": "String",
+            "length": 256
         }
     },
     "Visits_Table": {

--- a/features/initial_weed_visit_status_simple.feature
+++ b/features/initial_weed_visit_status_simple.feature
@@ -33,7 +33,7 @@ Feature: Set Visit status (WeedVisitStatus)
             Then the visits record has 'WeedVisitStatus' set to 'YellowKilledThisYear'
 
   	Rule:
-		* If 'Treated ?' = 'No' or 'Partially', status is set to YELLOW
+		* If 'Treated ?' = 'No' or 'Partially', status is set to RED
 
       Example: New observation controlled today with 'Treated' = 'No' (RED)
          Given iNaturalist has a new OMB observation with 'Date controlled' = today and 'Treated ?' = 'No'

--- a/features/multiple_weed_visits.feature
+++ b/features/multiple_weed_visits.feature
@@ -64,3 +64,19 @@ Feature: Set Visit status for records with multiple visits (WeedVisitStatus)
 	      And the third visits record has date 'DateCheck' set to today
 	      And the third visits record has 'WeedVisitStatus' set to 'GreenNoRegrowthThisYear'
 	      And the feature has 'ParentStatusWithDomain' set to 'GreenNoRegrowthThisYear'
+
+		@wip
+	   Example: CAMS visit followed by iNaturalist verification doesn't create a new visit
+	      Given iNaturalist has a new OMB observation with 'observed_on' = 2 years ago
+	      And that observation has been synced
+	      Then the WeedLocations feature has an associated record with 1 child visits record
+	      Given a new visits record was created in CAMS with status 'YellowKilledThisYear' yesterday
+	      Then the WeedLocations feature has an associated record with 2 child visits record
+	      Given the OMB observation is verified by another user
+	      When we process the observation
+	      Then the WeedLocations feature has an associated record with 2 child visits record
+	      And the first visits record has date 'DateCheck' set to 2 years ago
+	      And the first visits record has 'WeedVisitStatus' set to 'RedGrowth'
+	      And the second visits record has date 'DateCheck' set to yesterday
+	      And the second visits record has 'WeedVisitStatus' set to 'YellowKilledThisYear'
+	      And the feature has 'ParentStatusWithDomain' set to 'YellowKilledThisYear'

--- a/features/multiple_weed_visits.feature
+++ b/features/multiple_weed_visits.feature
@@ -65,14 +65,11 @@ Feature: Set Visit status for records with multiple visits (WeedVisitStatus)
 	      And the third visits record has 'WeedVisitStatus' set to 'GreenNoRegrowthThisYear'
 	      And the feature has 'ParentStatusWithDomain' set to 'GreenNoRegrowthThisYear'
 
-		@wip
 	   Example: CAMS visit followed by iNaturalist verification doesn't create a new visit
 	      Given iNaturalist has a new OMB observation with 'observed_on' = 2 years ago
 	      And that observation has been synced
-	      Then the WeedLocations feature has an associated record with 1 child visits record
-	      Given a new visits record was created in CAMS with status 'YellowKilledThisYear' yesterday
-	      Then the WeedLocations feature has an associated record with 2 child visits record
-	      Given the OMB observation is verified by another user
+	      And a new visits record was created in CAMS with status 'YellowKilledThisYear' yesterday
+	      And the OMB observation is verified by another user
 	      When we process the observation
 	      Then the WeedLocations feature has an associated record with 2 child visits record
 	      And the first visits record has date 'DateCheck' set to 2 years ago

--- a/features/multiple_weed_visits.feature
+++ b/features/multiple_weed_visits.feature
@@ -77,3 +77,44 @@ Feature: Set Visit status for records with multiple visits (WeedVisitStatus)
 	      And the second visits record has date 'DateCheck' set to yesterday
 	      And the second visits record has 'WeedVisitStatus' set to 'YellowKilledThisYear'
 	      And the feature has 'ParentStatusWithDomain' set to 'YellowKilledThisYear'
+
+	   Example: CAMS visit followed by iNaturalist visit does create a new visit
+	      Given iNaturalist has a new OMB observation with 'observed_on' = 2 years ago
+	      And that observation has been synced
+	      And a new visits record was created in CAMS with status 'YellowKilledThisYear' yesterday
+  		  And 'Date of status update' is updated to today
+	      And 'Status update' is updated to 'Dead / Not Present'
+	      When we process the observation
+	      Then the WeedLocations feature has an associated record with 3 child visits record
+	      And the first visits record has date 'DateCheck' set to 2 years ago
+	      And the first visits record has 'WeedVisitStatus' set to 'RedGrowth'
+	      And the second visits record has date 'DateCheck' set to yesterday
+	      And the second visits record has 'WeedVisitStatus' set to 'YellowKilledThisYear'
+	      And the third visits record has date 'DateCheck' set to today
+	      And the third visits record has 'WeedVisitStatus' set to 'GreenNoRegrowthThisYear'
+	      And the feature has 'ParentStatusWithDomain' set to 'GreenNoRegrowthThisYear'
+
+	   Example: Weed status rollover followed by iNaturalist verification doesn't create a new visit
+	      Given iNaturalist has a new OMB observation with 'observed_on' = 2 years ago
+	      And that observation has been synced
+	      And the weed instance status was rolled over to 'PurpleHistoric' yesterday
+	      And the OMB observation is verified by another user
+	      When we process the observation
+	      Then the WeedLocations feature has an associated record with 1 child visits record
+	      And the first visits record has date 'DateCheck' set to 2 years ago
+	      And the first visits record has 'WeedVisitStatus' set to 'RedGrowth'
+	      And the feature has 'ParentStatusWithDomain' set to 'PurpleHistoric'
+
+	   Example: Weed status rollover followed by iNaturalist visit does create a new visit
+	      Given iNaturalist has a new OMB observation with 'observed_on' = 2 years ago
+	      And that observation has been synced
+	      And the weed instance status was rolled over to 'PurpleHistoric' yesterday
+  		  And 'Date of status update' is updated to today
+	      And 'Status update' is updated to 'Dead / Not Present'
+	      When we process the observation
+	      Then the WeedLocations feature has an associated record with 2 child visits record
+	      And the first visits record has date 'DateCheck' set to 2 years ago
+	      And the first visits record has 'WeedVisitStatus' set to 'RedGrowth'
+	      And the second visits record has date 'DateCheck' set to today
+	      And the second visits record has 'WeedVisitStatus' set to 'GreenNoRegrowthThisYear'
+	      And the feature has 'ParentStatusWithDomain' set to 'GreenNoRegrowthThisYear'

--- a/inat_to_cams/cams_feature.py
+++ b/inat_to_cams/cams_feature.py
@@ -60,10 +60,11 @@ class WeedLocation:
         self.image_urls = None
         self.image_attribution = None
         self.location_accuracy = None
+        self.audit_log = None
 
     def __eq__(self, other):
         if type(other) is type(self):
-            ignore_keys = ['object_id', 'global_id']
+            ignore_keys = ['object_id', 'global_id', 'audit_log']
             ka = set(self.__dict__).difference(ignore_keys)
             kb = set(other.__dict__).difference(ignore_keys)
             return ka == kb and all(self.__dict__[k] == other.__dict__[k] for k in ka)

--- a/inat_to_cams/cams_interface.py
+++ b/inat_to_cams/cams_interface.py
@@ -183,6 +183,12 @@ class CamsConnection:
         logging.info(f'Global id {global_id}')
         return self.table.query(where=f"GUID_visits='{global_id}'", return_count_only=True)
 
+    @retry(delay=5, tries=3)
+    def get_feature_global_id(self, inat_id):
+        query = f"iNatRef='{inat_id}'"
+        row = self.query_weed_visits_table(query)
+        return row.features[0].attributes['GUID_visits']
+
     def get_location(self, global_id):
         query = f"globalId='{global_id}'"
         feature_set = self.query_weed_location_layer(query)

--- a/inat_to_cams/cams_reader.py
+++ b/inat_to_cams/cams_reader.py
@@ -82,6 +82,7 @@ class CamsReader:
             location.image_urls = featureRow.attributes['ImageURLs']
             location.image_attribution = featureRow.attributes['ImageAttribution']
             location.location_accuracy = featureRow.attributes['LocationAccuracy']
+            location.audit_log = featureRow.attributes['audit_log']
 
             # Temporarily until updated from weed visit by database trigger
             location.external_url = featureRow.attributes['iNatURL']

--- a/inat_to_cams/translator.py
+++ b/inat_to_cams/translator.py
@@ -61,6 +61,11 @@ class INatToCamsTranslator:
         weed_location.iNaturalist_longitude = inat_observation.location.x
         weed_location.iNaturalist_latitude = inat_observation.location.y
         weed_location.location_accuracy = inat_observation.location_accuracy
+        weed_location.image_urls = inat_observation.image_urls
+        weed_location.image_attribution = inat_observation.image_attribution
+        weed_location.external_url = f'https://www.inaturalist.org/observations/{inat_observation.id}'
+
+        # If we're not writing a new weed visit, the following weed_location fields will be reset in cams_writer.write_observation
         effort_to_control = inat_observation.effort_to_control
         if effort_to_control:
             effort_to_control = int(effort_to_control[:1])
@@ -69,10 +74,6 @@ class INatToCamsTranslator:
 
         weed_location.effort_to_control = effort_to_control
         weed_location.current_status = visit_status
-        weed_location.image_urls = inat_observation.image_urls
-        weed_location.image_attribution = inat_observation.image_attribution
-
-        weed_location.external_url = f'https://www.inaturalist.org/observations/{inat_observation.id}'
 
 
         weed_visit = cams_feature.WeedVisit()


### PR DESCRIPTION
- **Update title of test**
- **Added failing test for #137**
- **Ensure status is only updated and a new visit record created if visited in iNaturalist after it was visited in CAMS**
- **Cleaned up test**
- **Don't overwrite audit_log entries unless CAMS visit was more recent**
